### PR TITLE
fix: consume and produce metrics only in the specified order

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <script src="cvss_lookup.js?v=5"></script>
         <script src="max_composed.js?v=1"></script>
         <script src="max_hamming.js?v=1"></script>
+        <script src="metrics.js?v=1"></script>
         <link rel="stylesheet" href="https://unpkg.com/spectre.css@0.5.9/dist/spectre.min.css">
         <link rel="stylesheet" href="https://unpkg.com/spectre.css@0.5.9/dist/spectre-exp.min.css">
         <link rel="stylesheet" href="https://unpkg.com/spectre.css@0.5.9/dist/spectre-icons.min.css">

--- a/metrics.js
+++ b/metrics.js
@@ -1,0 +1,39 @@
+// CVSS v4.0 metrics ordering and valid values
+expectedMetricOrder = {
+    // Base
+    "AV": ["N", "A", "L", "P"],
+    "AC": ["L", "H"],
+    "AT": ["N", "P"],
+    "PR": ["N", "L", "H"],
+    "UI": ["N", "P", "A"],
+    "VC": ["H", "L", "N"],
+    "VI": ["H", "L", "N"],
+    "VA": ["H", "L", "N"],
+    "SC": ["H", "L", "N"],
+    "SI": ["H", "L", "N"],
+    "SA": ["H", "L", "N"],
+    // Threat
+    "E": ["X", "A", "P", "U"],
+    // Environmental
+    "CR":  ["X", "H", "M", "L"],
+    "IR":  ["X", "H", "M", "L"],
+    "AR":  ["X", "H", "M", "L"],
+    "MAV": ["X", "N", "A", "L", "P"],
+    "MAC": ["X", "L", "H"],
+    "MAT": ["X", "N", "P"],
+    "MPR": ["X", "N", "L", "H"],
+    "MUI": ["X", "N", "P", "A"],
+    "MVC": ["X", "H", "L", "N"],
+    "MVI": ["X", "H", "L", "N"],
+    "MVA": ["X", "H", "L", "N"],
+    "MSC": ["X", "H", "L", "N"],
+    "MSI": ["X", "S", "H", "L", "N"],
+    "MSA": ["X", "S", "H", "L", "N"],
+    // Supplemental
+    "S":  ["X", "N", "P"],
+    "AU": ["X", "N", "Y"],
+    "R":  ["X", "A", "U", "I"],
+    "V":  ["X", "D", "C"],
+    "RE": ["X", "L", "M", "H"],
+    "U":  ["X", "Clear", "Green", "Amnber", "Red"],
+}


### PR DESCRIPTION
This PR introduce a proposal to fix issues #24 #25 #34 in echo to our recent decision of strict metric ordering.
