### PR TITLE
fix(parsing): fix #36 by checking (non-)mandatory metrics

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,16 +83,32 @@ const app = Vue.createApp({
             oi = 0
             for(index in metrics) {
                 [key, value] = metrics[index].split(":")
+
                 expected = Object.entries(this.expectedMetricOrder)[oi++]
-                // There should not be any remaining metrics, or the metric is
-                // not at the right place
-                if(expected == undefined || key != expected[0]) {
-                    console.log("Error invalid vector")
-                    return
+                while(true) {
+                    // If out of possible metrics ordering, it not a valid value thus
+                    // the vector is invalid
+                    if(expected == undefined) {
+                        console.log("Error invalid vector, too many metric values")
+                        return
+                    }
+                    if(key != expected[0]) {
+                        // If not this metric but is mandatory, the vector is invalid
+                        // As the only mandatory ones are from the Base group, 11 is the
+                        // number of metrics part of it.
+                        if(oi <= 11) {
+                            console.log("Error invalid vector, missing mandatory metrics")
+                            return
+                        }
+                        // If a non-mandatory, retry
+                        expected = Object.entries(this.expectedMetricOrder)[oi++]
+                        continue
+                    }
+                    break
                 }
                 // The value MUST be part of the metric's values, case insensitive
                 if(!expected[1].includes(value)) {
-                    console.log("Error invalid vector")
+                    console.log("Error invalid vector, for key " + key + ", value " + value + " is not in " +expected[1])
                     return
                 }
                 if(key in this.cvssSelected) {

--- a/metrics.js
+++ b/metrics.js
@@ -1,6 +1,6 @@
 // CVSS v4.0 metrics ordering and valid values
 expectedMetricOrder = {
-    // Base
+    // Base (11 metrics)
     "AV": ["N", "A", "L", "P"],
     "AC": ["L", "H"],
     "AT": ["N", "P"],
@@ -12,9 +12,9 @@ expectedMetricOrder = {
     "SC": ["H", "L", "N"],
     "SI": ["H", "L", "N"],
     "SA": ["H", "L", "N"],
-    // Threat
+    // Threat (1 metric)
     "E": ["X", "A", "P", "U"],
-    // Environmental
+    // Environmental (14 metrics)
     "CR":  ["X", "H", "M", "L"],
     "IR":  ["X", "H", "M", "L"],
     "AR":  ["X", "H", "M", "L"],
@@ -29,7 +29,7 @@ expectedMetricOrder = {
     "MSC": ["X", "H", "L", "N"],
     "MSI": ["X", "S", "H", "L", "N"],
     "MSA": ["X", "S", "H", "L", "N"],
-    // Supplemental
+    // Supplemental (6 metrics)
     "S":  ["X", "N", "P"],
     "AU": ["X", "N", "Y"],
     "R":  ["X", "A", "U", "I"],


### PR DESCRIPTION
Due to the missing (non-)mandatory strategy being implemented through #35, this PR fixes the "non-sticky" non-mandatory metrics issue raised in #34 by @ViperGeek.

It also fixes the case in which the mandatory metrics were not part of the input vector (from the URL fragment/hash), which has been discovered during dev of the current fix.