### PR TITLE
The Value and Key for 'Not Defined' Option in CR_levels, IR_levels and AR_levels is missing

### DIFF
--- a/app.js
+++ b/app.js
@@ -290,9 +290,9 @@ const app = Vue.createApp({
             SI_levels = { 'S': 0.0, 'H': 0.1, 'L': 0.2, 'N': 0.3 }
             SA_levels = { 'S': 0.0, 'H': 0.1, 'L': 0.2, 'N': 0.3 }
 
-            CR_levels = { 'H': 0.0, 'M': 0.1, 'L': 0.2 }
-            IR_levels = { 'H': 0.0, 'M': 0.1, 'L': 0.2 }
-            AR_levels = { 'H': 0.0, 'M': 0.1, 'L': 0.2 }
+            CR_levels = { 'X':0.0, 'H': 0.0, 'M': 0.1, 'L': 0.2 }
+            IR_levels = { 'X':0.0, 'H': 0.0, 'M': 0.1, 'L': 0.2 }
+            AR_levels = { 'X':0.0, 'H': 0.0, 'M': 0.1, 'L': 0.2 }
 
             E_levels = { 'U': 0.2, 'P': 0.1, 'A': 0 }
 


### PR DESCRIPTION
When value of Confidentiality Requirements (CR), Integrity Requirements (IR) and Availability Requirements (AR) are 'Not Defined(X)' then on this line of code - 
severity_distance_CR = CR_levels[this.m("CR")] - CR_levels[this.extractValueMetric("CR", max_vector)]
CR_levels[X] does not exists in CR_levels = { 'H': 0.0, 'M': 0.1, 'L': 0.2 }.
Similarly it happening for IR and AR. 